### PR TITLE
[2022/06/06] 리액트 포탈이용해서 모달 구현, Dumb Components props 추가적으로 받게해주기,  간단한 상태 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,20 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
-      name="description"
+      name="WebGenie Website editor"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-
     <title>WebGenie</title>
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,0 +1,9 @@
+import reactDom from "react-dom";
+
+const ModalPortal = ({ children }) => {
+  const el = document.getElementById("modal-root");
+
+  return reactDom.createPortal(children, el);
+};
+
+export default ModalPortal;

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,9 +1,9 @@
 import reactDom from "react-dom";
 
 const ModalPortal = ({ children }) => {
-  const el = document.getElementById("modal-root");
+  const element = document.getElementById("modal-root");
 
-  return reactDom.createPortal(children, el);
+  return reactDom.createPortal(children, element);
 };
 
 export default ModalPortal;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,12 +1,21 @@
 import React from "react";
 import styled from "styled-components";
 
-function Button({ children, mainButton }) {
-  return <ButtonBody primaryButton={mainButton}>{children}</ButtonBody>;
+function Button({ children, mainButton, handleClick, margin }) {
+  return (
+    <ButtonBody
+      onClick={handleClick}
+      marginValue={margin}
+      primaryButton={mainButton}
+    >
+      {children}
+    </ButtonBody>
+  );
 }
 
 const ButtonBody = styled.button`
   padding: 8px 15px;
+  margin-top: ${(props) => (props.marginValue ? props.marginValue : "0")};
   box-sizing: border-box;
   box-shadow: ${(props) =>
     props.primaryButton

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { FaArrowLeft, FaRegEdit } from "react-icons/fa";
 import styled from "styled-components";
 
@@ -8,11 +8,53 @@ import EditorTemplate from "../EditorTemplate/EditorTemplate";
 import EditorToolbar from "../EditorToolbar/EditorToolbar";
 import Header from "../Header/Header";
 import LeftToolbar from "../LeftToolbar/LeftToolbar";
+import Modal from "../Modal/Modal";
+import ModalContent from "../ModalContent/ModalContent";
 import Navigation from "../Navigation/Navigation";
 
 function Editor() {
+  const [shouldDisplayModal, setShouldDisplayModal] = useState(false);
+  const [messageContent, setMessageContent] = useState("");
+  const [buttonText, setButtonText] = useState("");
+  const [modalIconState, setModalIconState] = useState("");
+  const [shouldEditTitle, setShouldEditTitle] = useState(false);
+  const [editorTitle, setEditorTitle] = useState("New Title 2");
+
+  const toggleSaveModal = () => {
+    setShouldDisplayModal(!shouldDisplayModal);
+    setMessageContent("현재 웹사이트를 저장하시겠습니까?");
+    setButtonText("네, 저장할게요");
+    setModalIconState("save");
+  };
+
+  const togglePublishModal = () => {
+    setShouldDisplayModal(!shouldDisplayModal);
+    setMessageContent("현재 웹사이트를 배포하시겠습니까?");
+    setButtonText("네, 배포할게요");
+    setModalIconState("deploy");
+  };
+
+  const handleTitleChangeState = () => {
+    setShouldEditTitle(!shouldEditTitle);
+  };
+
+  const listenTitleInputChange = (ev) => {
+    setEditorTitle(ev.target.value);
+  };
+
   return (
     <>
+      {shouldDisplayModal && (
+        <Modal>
+          <ModalContent
+            modalText={messageContent}
+            primaryButtonText={buttonText}
+            secondaryButtonText={"아니요"}
+            modalIconState={modalIconState}
+            handleClick={toggleSaveModal}
+          />
+        </Modal>
+      )}
       <Header>
         <h1>WebGenie</h1>
         <img src={mockImage} />
@@ -23,15 +65,22 @@ function Editor() {
             <FaArrowLeft />
           </span>
           <div className="titleNavbar">
-            <h3>New Editor 2</h3>
-            <span>
+            {!shouldEditTitle && <h3>{editorTitle}</h3>}
+            {shouldEditTitle && (
+              <input onChange={listenTitleInputChange}></input>
+            )}
+            <span onClick={handleTitleChangeState}>
               <FaRegEdit />
             </span>
           </div>
         </div>
         <div>
-          <Button mainButton={false}>Save</Button>
-          <Button mainButton={true}>Publish</Button>
+          <Button handleClick={toggleSaveModal} mainButton={false}>
+            Save
+          </Button>
+          <Button handleClick={togglePublishModal} mainButton={true}>
+            Publish
+          </Button>
         </div>
       </Navigation>
       <EditorBody>

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -38,8 +38,8 @@ function Editor() {
     setShouldEditTitle(!shouldEditTitle);
   };
 
-  const listenTitleInputChange = (ev) => {
-    setEditorTitle(ev.target.value);
+  const listenTitleInputChange = (event) => {
+    setEditorTitle(event.target.value);
   };
 
   return (
@@ -66,9 +66,7 @@ function Editor() {
           </span>
           <div className="titleNavbar">
             {!shouldEditTitle && <h3>{editorTitle}</h3>}
-            {shouldEditTitle && (
-              <input onChange={listenTitleInputChange}></input>
-            )}
+            {shouldEditTitle && <input onChange={listenTitleInputChange} />}
             <span onClick={handleTitleChangeState}>
               <FaRegEdit />
             </span>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -14,24 +14,24 @@ function Modal({ children }) {
 }
 
 const ModalContainer = styled.div`
-  height: 100%;
-  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 100%;
+  width: 100%;
   position: fixed;
   left: 0;
   top: 0;
-  text-align: center;
   background-color: rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(2px);
+  text-align: center;
 `;
 
 const ModalBody = styled.div`
-  background-color: white;
   width: 460px;
   height: 400px;
   border-radius: 7px;
+  background-color: white;
 
   div {
     display: flex;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,65 @@
+import React from "react";
+import styled from "styled-components";
+
+import ModalPortal from "../../Portal";
+
+function Modal({ children }) {
+  return (
+    <ModalPortal>
+      <ModalContainer>
+        <ModalBody>{children}</ModalBody>
+      </ModalContainer>
+    </ModalPortal>
+  );
+}
+
+const ModalContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  left: 0;
+  top: 0;
+  text-align: center;
+  background-color: rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(2px);
+`;
+
+const ModalBody = styled.div`
+  background-color: white;
+  width: 460px;
+  height: 400px;
+  border-radius: 7px;
+
+  div {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    margin: 30px;
+  }
+
+  h1 {
+    margin-top: 10px;
+    margin-bottom: 30px;
+    font-size: 80px;
+  }
+
+  h2 {
+    margin-bottom: 40px;
+    color: #54595e;
+  }
+
+  h3 {
+    font-size: 28px;
+    text-align: end;
+    cursor: pointer;
+
+    :hover {
+      opacity: 0.5;
+    }
+  }
+`;
+
+export default Modal;

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -1,0 +1,32 @@
+import { FcGlobe, FcMultipleInputs, FcQuestions } from "react-icons/fc";
+import { MdClose } from "react-icons/md";
+
+import Button from "../Button/Button";
+
+function ModalContent({
+  modalText = "",
+  primaryButtonText = "",
+  secondaryButtonText = "",
+  modalIconState,
+  handleClick,
+}) {
+  const modalIconMap = {
+    question: <FcQuestions />,
+    deploy: <FcGlobe />,
+    save: <FcMultipleInputs />,
+  };
+
+  return (
+    <div>
+      <h3>
+        <MdClose onClick={handleClick} />
+      </h3>
+      <h1>{modalIconMap[modalIconState]}</h1>
+      <h2>{modalText}</h2>
+      <Button mainButton={true}>{primaryButtonText}</Button>
+      <Button margin="13px">{secondaryButtonText}</Button>
+    </div>
+  );
+}
+
+export default ModalContent;

--- a/src/components/ToolbarContainer/ToolbarContainer.js
+++ b/src/components/ToolbarContainer/ToolbarContainer.js
@@ -12,8 +12,8 @@ const ToolbarContainerBody = styled.div`
   color: #263238;
 
   .category {
-    font-size: 18px;
     margin-bottom: 10px;
+    font-size: 18px;
     text-decoration: underline;
     font-weight: 600;
   }
@@ -25,58 +25,58 @@ const ToolbarContainerBody = styled.div`
   }
 
   h1 {
-    font-size: 32px;
     margin-bottom: 7px;
-    font-weight: 500;
     color: #263238;
+    font-size: 32px;
+    font-weight: 500;
     cursor: pointer;
   }
 
   h2 {
-    font-size: 28px;
     margin-bottom: 7px;
-    font-weight: 500;
     color: #263238;
+    font-size: 28px;
+    font-weight: 500;
     cursor: pointer;
   }
 
   h3 {
-    font-size: 24px;
     margin-bottom: 7px;
-    font-weight: 500;
     color: #263238;
+    font-size: 24px;
+    font-weight: 500;
     cursor: pointer;
   }
 
   h4 {
-    font-size: 20px;
     margin-bottom: 7px;
-    font-weight: 500;
     color: #263238;
+    font-size: 20px;
+    font-weight: 500;
     cursor: pointer;
   }
 
   h5 {
-    font-size: 16px;
     margin-bottom: 7px;
-    font-weight: 500;
     color: #263238;
+    font-size: 16px;
+    font-weight: 500;
     cursor: pointer;
   }
 
   h6 {
+    color: #263238;
     font-size: 12px;
     font-weight: 500;
-    color: #263238;
     cursor: pointer;
   }
 
   .textbox {
+    width: 120px;
     padding: 5px 20px;
     border: 1px solid #d5d8de;
     border-radius: 5px;
     font-size: 15px;
-    width: 120px;
     cursor: pointer;
 
     ::placeholder {
@@ -131,9 +131,9 @@ const ToolbarContainerBody = styled.div`
   }
 
   .colorPalette {
-    margin-left: 10px;
     width: 20px;
     height: 20px;
+    margin-left: 10px;
     border: none;
     background: white;
     cursor: default;

--- a/src/components/UserPage/UserPage.js
+++ b/src/components/UserPage/UserPage.js
@@ -4,11 +4,15 @@ import mockImage from "../../assets/mockData.png";
 import api from "../../services/api";
 import Button from "../Button/Button";
 import Header from "../Header/Header";
+import Modal from "../Modal/Modal";
+import ModalContent from "../ModalContent/ModalContent";
 import Navigation from "../Navigation/Navigation";
 import UserCollection from "../UserCollection/UserCollection";
 
 function UserPage() {
   const [userInformation, setUserInformation] = useState({});
+  const [shouldDisplayModal, setShouldDisplayModal] = useState(false);
+
   const accessToken = localStorage.getItem("accessToken");
 
   useEffect(() => {
@@ -29,8 +33,23 @@ function UserPage() {
     fetchUser();
   }, []);
 
+  const toggleCreateNewSiteModal = () => {
+    setShouldDisplayModal(!shouldDisplayModal);
+  };
+
   return (
     <>
+      {shouldDisplayModal && (
+        <Modal>
+          <ModalContent
+            modalText={"새로운 웹사이트 에디터를 생성할까요?"}
+            primaryButtonText={"네, 만들어주세요"}
+            secondaryButtonText={"아니요"}
+            modalIconState={"question"}
+            handleClick={toggleCreateNewSiteModal}
+          />
+        </Modal>
+      )}
       <Header>
         <h1>WebGenie</h1>
         <img src={mockImage} />
@@ -40,7 +59,9 @@ function UserPage() {
         <form>
           <input placeholder="Search your websites" />
         </form>
-        <Button mainButton={true}>Create New Site</Button>
+        <Button handleClick={toggleCreateNewSiteModal} mainButton={true}>
+          Create New Site
+        </Button>
       </Navigation>
       {userInformation && (
         <UserCollection collections={userInformation.userCollections} />


### PR DESCRIPTION
## 요약
- Modal 구현
- Modal 내용을 담아서 dynamic하게 보여줄 컴포넌트 구현
- useState을 이용해서 상태 추가
- CRA boilerplate 수정

## 작업사항
- 모달을 구현했습니다. 예전에 사용해보지 못한 포탈을 이용해서 도전해봤는데 예전에 했던 거보다 더 깔끔하게 구현이 된 거 같아서 만족스럽네요. 모달을 구현하고 추가적으로 ModalContent라는 컴포넌트도 구현해봤습니다. ModalContent컴포넌트가 없으니깐 너무 Nesting되서 code splitting을 해봤습니다. 개인적으로 조금 더 분리가 잘 되지않앗나라고 생각은 하지만 확실하지는 않습니다.
- 추가적으로 CRA로 설치후 받은 public/index.html 파일을 조금 수정해봤습니다. Boilerplate코드가 cra내용이 있어서 조금 삭제해봤습니다.
- 간단하게 useState을 이용해서 상태를 추가해봤습니다. 반복되는 함수도 있고 해서 utils로 빼던지 해야 한다고 생각이 듭니다.


![새로운 Editor추가 모달](https://user-images.githubusercontent.com/83770081/172145957-c8074d14-c6a8-4c7e-934a-e9d61a169d8a.gif)


![저장 + 배포 모달 정보](https://user-images.githubusercontent.com/83770081/172146145-263ca6a6-ba4f-4344-bc89-bd47e1f844bb.gif)


![Editor 제목 수정 기능](https://user-images.githubusercontent.com/83770081/172145968-db371912-aa40-489f-a737-ba089e06d426.gif)


## 변경로직
- 변경된 로직은 없습니다.


### 변경전
- 변경전 로직은 없습니다.

### 변경후
- 변경후 로직은 없습니다.

## 기타
- 중복되는 로직이 조금 보이고, button 컴포넌트를 조금더 dynamic하게 사용하기 위해 props을 추가적으로 전달해주는 방식을 적용해봤습니다. 어떻게 더 개선을 해야 할지 모르겠습니다. 완벽하게 재사용할 수 있는 컴포넌트를 하나 만드는건 매우 힘들어 보이고 계속 수정과정을 해야하고, 나중에 엄청나게 더러워지는 컴포넌트가 될 거 같습니다.
- 추가적으로 컴포넌트들을 code splitting을 해보려고합니다. 중복되는 코드가 좀 많아보이고 분리해줄수있을꺼같습니다.
- 리뷰해 주셔서 감사합니다 🙇🏻‍♂️
