### PR TITLE
[2022/06/12] 사용자 Editor저장,불러오기, 제목 수정기능

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -11,6 +11,7 @@ import useAxios from "../hooks/useAxios";
 import useInput from "../hooks/useInput";
 import useLogout from "../hooks/useLogout";
 import useModal from "../hooks/useModal";
+import { retrieveURL } from "../utils/index";
 import Button from "./Button";
 import EditorTemplate from "./EditorTemplate";
 import Header from "./Header";
@@ -22,27 +23,21 @@ import Navigation from "./Navigation";
 import RightToolbar from "./RightToolbar";
 
 function Editor() {
-  const { editor } = useContext(UserContext);
+  const currentEditorId = retrieveURL();
+  const { editor, title } = useContext(UserContext);
   const { handleLogout } = useLogout();
-  let currentEditorId = window.location.pathname
-    .split("/")
-    .filter((item) => item !== "editor")
-    .join("");
-  const {
-    userTitle,
-    shouldEditValue,
-    handleInputChange,
-    toggleInputChange,
-    setUserTitle,
-  } = useInput("editor", editor);
+  const { userTitle, shouldEditValue, handleInputChange, toggleInputChange } =
+    useInput("editor", editor);
   const [shouldShowWideView, setShouldShowWideView] = useState(false);
   const {
     shouldDisplayModal,
     saveModalToggle,
     publishModalToggle,
     closeModal,
+    setUserCode,
     message,
   } = useModal(userTitle, currentEditorId);
+
   const toggleWideView = () => {
     setShouldShowWideView((state) => !state);
   };
@@ -63,15 +58,10 @@ function Editor() {
   useEffect(() => {
     if (editor) return;
 
-    setUserTitle(null);
     fetchData();
   }, []);
 
   if (!editor) {
-    return <Loader />;
-  }
-
-  if (!userTitle && !shouldEditValue) {
     return <Loader />;
   }
 
@@ -105,7 +95,7 @@ function Editor() {
           </a>
           <div className="titleNavbar">
             {!shouldEditValue ? (
-              <h3>{userTitle}</h3>
+              <h3>{title === userTitle ? title : userTitle}</h3>
             ) : (
               <input onChange={handleInputChange} />
             )}
@@ -128,7 +118,12 @@ function Editor() {
       </Navigation>
       <EditorBody>
         {!shouldShowWideView && <LeftToolbar />}
-        <EditorTemplate displayWideView={shouldShowWideView} />
+        <EditorTemplate
+          modalStatus={shouldDisplayModal}
+          saveUserCode={setUserCode}
+          editorInformation={editor}
+          displayWideView={shouldShowWideView}
+        />
         {!shouldShowWideView && <RightToolbar />}
       </EditorBody>
     </>

--- a/src/components/EditorTemplate.js
+++ b/src/components/EditorTemplate.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 
 import useDragAndDrop from "../hooks/useDragAndDrop";
@@ -10,13 +10,32 @@ import {
   handleDrop,
 } from "../utils";
 
-function EditorTemplate({ displayWideView, colorName }) {
+function EditorTemplate({
+  displayWideView,
+  colorName,
+  modalStatus,
+  saveUserCode,
+  editorInformation,
+}) {
   const [handleResizeTarget, isResizing, setIsResizing] = useResize();
   const [parentRef, targetRef] = useDragAndDrop(isResizing, setIsResizing);
 
   if (targetRef.current !== null && targetRef.current.tagName !== "DIV") {
     targetRef.current.style.background = colorName;
   }
+
+  useEffect(() => {
+    if (!modalStatus) return;
+    if (!parentRef.current) return;
+
+    saveUserCode(parentRef.current.innerHTML);
+  }, [modalStatus]);
+
+  useEffect(() => {
+    if (!editorInformation.result) return;
+
+    parentRef.current.innerHTML = editorInformation.result.userSavedCode;
+  }, [editorInformation.result[0]]);
 
   return (
     <EditorTemplateBody
@@ -27,6 +46,7 @@ function EditorTemplate({ displayWideView, colorName }) {
       onDragLeave={handleDragLeave}
       onClick={handleResizeTarget}
       wideView={displayWideView}
+      onChange={() => console.log("hi")}
     />
   );
 }

--- a/src/context/userContext.js
+++ b/src/context/userContext.js
@@ -9,6 +9,8 @@ const UserContextTypeProvider = ({ children }) => {
   const [fetchedData, setFetchedData] = useState(null);
   const [editor, setEditor] = useState(null);
   const [isLoggedIn, setIsLoggedIn] = useState(localStorage.getItem(ID_TOKEN));
+  const [title, setTitle] = useState();
+  const [userCode, setUserCode] = useState();
 
   return (
     <UserContext.Provider
@@ -21,6 +23,10 @@ const UserContextTypeProvider = ({ children }) => {
         setIsLoggedIn,
         setUserInformation,
         setEditor,
+        title,
+        setTitle,
+        userCode,
+        setUserCode,
       }}
     >
       {children}

--- a/src/hooks/useAxios.js
+++ b/src/hooks/useAxios.js
@@ -5,7 +5,7 @@ import { UserContext } from "../context/userContext";
 import api from "../services/api";
 
 const useAxios = (params, idToken, category = null) => {
-  const { setFetchedData, setUserInformation, setEditor } =
+  const { setFetchedData, setUserInformation, setEditor, setTitle } =
     useContext(UserContext);
   const navigate = useNavigate();
 
@@ -28,7 +28,9 @@ const useAxios = (params, idToken, category = null) => {
 
       const result = await api(params);
 
-      navigate(`/editor/${result.data._id}`);
+      setTitle(result.data.changedTitle);
+      setEditor(result.data);
+      navigate(`/editor/${result.data.result._id}`);
     } else {
       navigate("/creatingnewwebsite");
 

--- a/src/hooks/useDragAndDrop.js
+++ b/src/hooks/useDragAndDrop.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-function useDragAndDrop(resizingState, setResizingState) {
+function useDragAndDrop(resizingState) {
   const targetRef = useRef(null);
   const parentRef = useRef(null);
   const [isDragging, setIsDragging] = useState(false);

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   ID_TOKEN,
@@ -7,9 +7,12 @@ import {
   PUBLISH_MODAL_MESSAGE,
   SAVE_MODAL_MESSAGE,
 } from "../constants/constants";
+import { retrieveURL } from "../utils";
 
 const useModal = (editorTitle, editorId) => {
+  const currentEditorId = retrieveURL();
   const [shouldDisplayModal, setShouldDisplayModal] = useState(false);
+  const [userCode, setUserCode] = useState();
   const [message, setMessage] = useState({
     titleMessage: null,
     proceedButtonText: null,
@@ -38,21 +41,6 @@ const useModal = (editorTitle, editorId) => {
 
   const saveModalToggle = () => {
     setShouldDisplayModal((state) => !state);
-    setMessage({
-      titleMessage: SAVE_MODAL_MESSAGE.titleMessage,
-      proceedButtonText: SAVE_MODAL_MESSAGE.acceptButtonMessage,
-      denyButtonText: SAVE_MODAL_MESSAGE.denyButtonMessage,
-      iconType: MODAL_ICON_STATE.saveState,
-      params: {
-        method: "patch",
-        url: "/websites/:website_id",
-        data: { title: editorTitle, userCode: "", websiteId: editorId },
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem(ID_TOKEN)}`,
-        },
-      },
-      requestType: "Save",
-    });
   };
 
   const publishModalToggle = useCallback(() => {
@@ -80,6 +68,28 @@ const useModal = (editorTitle, editorId) => {
     []
   );
 
+  useEffect(() => {
+    setMessage({
+      titleMessage: SAVE_MODAL_MESSAGE.titleMessage,
+      proceedButtonText: SAVE_MODAL_MESSAGE.acceptButtonMessage,
+      denyButtonText: SAVE_MODAL_MESSAGE.denyButtonMessage,
+      iconType: MODAL_ICON_STATE.saveState,
+      params: {
+        method: "patch",
+        url: "/websites/:website_id",
+        data: {
+          title: editorTitle,
+          editorCode: userCode,
+          websiteId: currentEditorId,
+        },
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem(ID_TOKEN)}`,
+        },
+      },
+      requestType: "Save",
+    });
+  }, [userCode]);
+
   return {
     shouldDisplayModal,
     createNewSiteModalToggle,
@@ -87,6 +97,8 @@ const useModal = (editorTitle, editorId) => {
     publishModalToggle,
     closeModal,
     message,
+    userCode,
+    setUserCode,
   };
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -62,3 +62,12 @@ export function getElementValue(
 
   return currentElementValue;
 }
+
+export const retrieveURL = () => {
+  const currentEditorId = window.location.pathname
+    .split("/")
+    .filter((item) => item !== "editor")
+    .join("");
+
+  return currentEditorId;
+};


### PR DESCRIPTION
## 요약
- 사용자 Editor 저장 기능 + 제목 수정 기능
- 사용자가 저장한 Editor 불러오기 기능

## 작업사항
- 사용자가 저장한 Editor 저장 기능, 제목 수정 + 저장된 Editor 불러와 주는 로직을 작성해봤습니다. 중간에 서버와 통신하는 과정에서 문제가 있어서 생각보다 오래 걸렸네요.
- 추가로 저장해줄 때 useModal내부에서 params을 전달해주는 게 useEffect을 사용하지 않으니깐 저장하기 전값이 적용되어서 useEffect을 이용해서 useAxios로 전달해줄 params을 만들어줘 봤습니다!


![Editor 저장 preview](https://user-images.githubusercontent.com/83770081/173198090-6f219555-f4f6-4b5a-b2d4-b2f8b9584467.gif)


## 변경로직
- 변경 로직 없습니다.

### 변경전
- 변경전 로직 없습니다.

### 변경후
- 변경후 로직 없습니다.

## 기타
- 로직이 반복되는 부분을 utility함수로 빼고 context API을 통해서 사용자가 수정한 제목을 관리해주는 로직을 작성해봤습니다!
- 코드가 점점 복잡해지고 있는데 최대한 노력해서 클린코드를 작성해보겠습니다!
- 너무 한 작업에 시간을 오래 쓴 거 같네요! 다음 삭제 기능 빠르게 구현하겠습니다~
- 코드 리뷰해 주셔서 미리 감사합니다 🙇🏻‍♂️
