### PR TITLE
[2022/06/12] 사용자 메인 페이지에서 Editor 삭제 모달 + 요청 로직 추가

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -11,6 +11,7 @@ import useAxios from "../hooks/useAxios";
 import useInput from "../hooks/useInput";
 import useLogout from "../hooks/useLogout";
 import useModal from "../hooks/useModal";
+import { retrieveURL } from "../utils/index";
 import Button from "./Button";
 import EditorTemplate from "./EditorTemplate";
 import Header from "./Header";
@@ -22,27 +23,21 @@ import Navigation from "./Navigation";
 import RightToolbar from "./RightToolbar";
 
 function Editor() {
-  const { editor } = useContext(UserContext);
+  const currentEditorId = retrieveURL();
+  const { editor, title } = useContext(UserContext);
   const { handleLogout } = useLogout();
-  let currentEditorId = window.location.pathname
-    .split("/")
-    .filter((item) => item !== "editor")
-    .join("");
-  const {
-    userTitle,
-    shouldEditValue,
-    handleInputChange,
-    toggleInputChange,
-    setUserTitle,
-  } = useInput("editor", editor);
+  const { userTitle, shouldEditValue, handleInputChange, toggleInputChange } =
+    useInput("editor", editor);
   const [shouldShowWideView, setShouldShowWideView] = useState(false);
   const {
     shouldDisplayModal,
     saveModalToggle,
     publishModalToggle,
     closeModal,
+    setUserCode,
     message,
   } = useModal(userTitle, currentEditorId);
+
   const toggleWideView = () => {
     setShouldShowWideView((state) => !state);
   };
@@ -63,15 +58,10 @@ function Editor() {
   useEffect(() => {
     if (editor) return;
 
-    setUserTitle(null);
     fetchData();
   }, []);
 
   if (!editor) {
-    return <Loader />;
-  }
-
-  if (!userTitle && !shouldEditValue) {
     return <Loader />;
   }
 
@@ -105,7 +95,7 @@ function Editor() {
           </a>
           <div className="titleNavbar">
             {!shouldEditValue ? (
-              <h3>{userTitle}</h3>
+              <h3>{title === userTitle ? title : userTitle}</h3>
             ) : (
               <input onChange={handleInputChange} />
             )}
@@ -128,7 +118,12 @@ function Editor() {
       </Navigation>
       <EditorBody>
         {!shouldShowWideView && <LeftToolbar />}
-        <EditorTemplate displayWideView={shouldShowWideView} />
+        <EditorTemplate
+          modalStatus={shouldDisplayModal}
+          saveUserCode={setUserCode}
+          editorInformation={editor}
+          displayWideView={shouldShowWideView}
+        />
         {!shouldShowWideView && <RightToolbar />}
       </EditorBody>
     </>

--- a/src/components/EditorTemplate.js
+++ b/src/components/EditorTemplate.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 
 import useDragAndDrop from "../hooks/useDragAndDrop";
@@ -10,13 +10,32 @@ import {
   handleDrop,
 } from "../utils";
 
-function EditorTemplate({ displayWideView, colorName }) {
+function EditorTemplate({
+  displayWideView,
+  colorName,
+  modalStatus,
+  saveUserCode,
+  editorInformation,
+}) {
   const [handleResizeTarget, isResizing, setIsResizing] = useResize();
   const [parentRef, targetRef] = useDragAndDrop(isResizing, setIsResizing);
 
   if (targetRef.current !== null && targetRef.current.tagName !== "DIV") {
     targetRef.current.style.background = colorName;
   }
+
+  useEffect(() => {
+    if (!modalStatus) return;
+    if (!parentRef.current) return;
+
+    saveUserCode(parentRef.current.innerHTML);
+  }, [modalStatus]);
+
+  useEffect(() => {
+    if (!editorInformation.result) return;
+
+    parentRef.current.innerHTML = editorInformation.result.userSavedCode;
+  }, [editorInformation.result[0]]);
 
   return (
     <EditorTemplateBody
@@ -27,6 +46,7 @@ function EditorTemplate({ displayWideView, colorName }) {
       onDragLeave={handleDragLeave}
       onClick={handleResizeTarget}
       wideView={displayWideView}
+      onChange={() => console.log("hi")}
     />
   );
 }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -25,6 +25,7 @@ const ModalContainer = styled.div`
   background-color: rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(2px);
   text-align: center;
+  z-index: 1000;
 `;
 
 const ModalBody = styled.div`

--- a/src/components/ModalContent.js
+++ b/src/components/ModalContent.js
@@ -1,4 +1,9 @@
-import { FcGlobe, FcMultipleInputs, FcQuestions } from "react-icons/fc";
+import {
+  FcFullTrash,
+  FcGlobe,
+  FcMultipleInputs,
+  FcQuestions,
+} from "react-icons/fc";
 import { MdClose } from "react-icons/md";
 import styled from "styled-components";
 
@@ -19,6 +24,7 @@ function ModalContent({
     question: <FcQuestions />,
     deploy: <FcGlobe />,
     save: <FcMultipleInputs />,
+    delete: <FcFullTrash />,
   };
 
   const { fetchData } = useAxios(

--- a/src/components/UserCollection.js
+++ b/src/components/UserCollection.js
@@ -57,8 +57,8 @@ const UserWebsites = styled.div`
   box-shadow: 0px 10px 15px 0px rgba(0, 0, 0, 0.25);
   border-radius: 10px;
   background-color: white;
-  cursor: pointer;
   transition: all 0.3s ease;
+  cursor: pointer;
 
   div {
     display: flex;

--- a/src/components/UserCollection.js
+++ b/src/components/UserCollection.js
@@ -1,15 +1,19 @@
+import { MdClose } from "react-icons/md";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 import emptyCollection from "../assets/emptyCollection.png";
 import placeholderImage from "../assets/placeholder.png";
 
-function UserCollection({ collections }) {
+function UserCollection({ collections, toggleDeleteModal }) {
   return (
     <UserContents>
       {collections.length ? (
         collections.map((userWebsites) => (
           <UserWebsites key={userWebsites._id}>
+            <h3 value={userWebsites._id}>
+              <MdClose onClick={toggleDeleteModal} value={userWebsites._id} />
+            </h3>
             <Link to={`/editor/${userWebsites._id}`}>
               <img src={placeholderImage} />
               <div>
@@ -42,6 +46,7 @@ const UserContents = styled.div`
 `;
 
 const UserWebsites = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -68,6 +73,7 @@ const UserWebsites = styled.div`
     height: 150px;
     width: 300px;
     border-radius: 10px 10px 0px 0px;
+    user-select: none;
   }
 
   p {
@@ -77,9 +83,34 @@ const UserWebsites = styled.div`
     color: black;
   }
 
-  :hover {
-    opacity: 0.6;
-    transform: scale(1.1);
+  h3 {
+    position: absolute;
+    z-index: 100;
+    width: 30px;
+    height: 30px;
+    right: -10px;
+    top: -10px;
+    font-size: 30px;
+    color: white;
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 50%;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    :hover {
+      transform: scale(1.2);
+    }
+  }
+
+  a {
+    transition: all 0.3s ease;
+
+    :hover {
+      opacity: 0.6;
+    }
+  }
+
+  path {
+    pointer-events: none;
   }
 `;
 

--- a/src/components/UserWebsites.js
+++ b/src/components/UserWebsites.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useLayoutEffect, useState } from "react";
 import styled from "styled-components";
 
 import { REQUEST_DATA_INFORMATION_USER } from "../constants/constants";
@@ -16,8 +16,13 @@ import Navigation from "./Navigation";
 import UserCollection from "./UserCollection";
 
 function UserPage() {
-  const { shouldDisplayModal, createNewSiteModalToggle, closeModal, message } =
-    useModal();
+  const {
+    shouldDisplayModal,
+    createNewSiteModalToggle,
+    deleteSiteModalMessage,
+    closeModal,
+    message,
+  } = useModal();
   const { handleLogout } = useLogout();
   const { userInformation } = useContext(UserContext);
   const idToken = localStorage.getItem(ID_TOKEN);
@@ -34,6 +39,8 @@ function UserPage() {
   );
 
   useEffect(() => {
+    if (userInformation) return;
+
     fetchData();
   }, []);
 
@@ -50,6 +57,7 @@ function UserPage() {
             primaryButtonText={message.proceedButtonText}
             secondaryButtonText={message.denyButtonText}
             modalIconState={message.iconType}
+            requestType={message.modalType}
             params={message.params}
             handleClick={closeModal}
           />
@@ -74,7 +82,10 @@ function UserPage() {
         </Button>
       </Navigation>
       {userInformation && (
-        <UserCollection collections={userInformation.websites} />
+        <UserCollection
+          toggleDeleteModal={deleteSiteModalMessage}
+          collections={userInformation.websites}
+        />
       )}
     </>
   );

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -16,10 +16,17 @@ export const PUBLISH_MODAL_MESSAGE = {
   denyButtonMessage: "아직 배포하기 싫어요.",
 };
 
+export const DELETE_MODAL_MESSAGE = {
+  titleMessage: "정말로 삭제하시겠습니까?",
+  acceptButtonMessage: "네, 삭제시켜주세요.",
+  denyButtonMessage: "아니요, 삭제하기 싫어요.",
+};
+
 export const MODAL_ICON_STATE = {
   questionState: "question",
   deployState: "deploy",
   saveState: "save",
+  deleteState: "delete",
 };
 
 export const NO_MESSAGE = "아니요.";

--- a/src/context/userContext.js
+++ b/src/context/userContext.js
@@ -9,6 +9,8 @@ const UserContextTypeProvider = ({ children }) => {
   const [fetchedData, setFetchedData] = useState(null);
   const [editor, setEditor] = useState(null);
   const [isLoggedIn, setIsLoggedIn] = useState(localStorage.getItem(ID_TOKEN));
+  const [title, setTitle] = useState();
+  const [userCode, setUserCode] = useState();
 
   return (
     <UserContext.Provider
@@ -21,6 +23,10 @@ const UserContextTypeProvider = ({ children }) => {
         setIsLoggedIn,
         setUserInformation,
         setEditor,
+        title,
+        setTitle,
+        userCode,
+        setUserCode,
       }}
     >
       {children}

--- a/src/hooks/useAxios.js
+++ b/src/hooks/useAxios.js
@@ -31,6 +31,13 @@ const useAxios = (params, idToken, category = null) => {
       setTitle(result.data.changedTitle);
       setEditor(result.data);
       navigate(`/editor/${result.data.result._id}`);
+    } else if (category === "delete") {
+      navigate("/creatingnewwebsite");
+
+      const result = await api(params);
+
+      setUserInformation(result.data);
+      navigate("/");
     } else {
       navigate("/creatingnewwebsite");
 

--- a/src/hooks/useAxios.js
+++ b/src/hooks/useAxios.js
@@ -5,7 +5,7 @@ import { UserContext } from "../context/userContext";
 import api from "../services/api";
 
 const useAxios = (params, idToken, category = null) => {
-  const { setFetchedData, setUserInformation, setEditor } =
+  const { setFetchedData, setUserInformation, setEditor, setTitle } =
     useContext(UserContext);
   const navigate = useNavigate();
 
@@ -28,7 +28,9 @@ const useAxios = (params, idToken, category = null) => {
 
       const result = await api(params);
 
-      navigate(`/editor/${result.data._id}`);
+      setTitle(result.data.changedTitle);
+      setEditor(result.data);
+      navigate(`/editor/${result.data.result._id}`);
     } else {
       navigate("/creatingnewwebsite");
 

--- a/src/hooks/useDragAndDrop.js
+++ b/src/hooks/useDragAndDrop.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-function useDragAndDrop(resizingState, setResizingState) {
+function useDragAndDrop(resizingState) {
   const targetRef = useRef(null);
   const parentRef = useRef(null);
   const [isDragging, setIsDragging] = useState(false);

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   ID_TOKEN,
@@ -7,9 +7,12 @@ import {
   PUBLISH_MODAL_MESSAGE,
   SAVE_MODAL_MESSAGE,
 } from "../constants/constants";
+import { retrieveURL } from "../utils";
 
 const useModal = (editorTitle, editorId) => {
+  const currentEditorId = retrieveURL();
   const [shouldDisplayModal, setShouldDisplayModal] = useState(false);
+  const [userCode, setUserCode] = useState();
   const [message, setMessage] = useState({
     titleMessage: null,
     proceedButtonText: null,
@@ -38,21 +41,6 @@ const useModal = (editorTitle, editorId) => {
 
   const saveModalToggle = () => {
     setShouldDisplayModal((state) => !state);
-    setMessage({
-      titleMessage: SAVE_MODAL_MESSAGE.titleMessage,
-      proceedButtonText: SAVE_MODAL_MESSAGE.acceptButtonMessage,
-      denyButtonText: SAVE_MODAL_MESSAGE.denyButtonMessage,
-      iconType: MODAL_ICON_STATE.saveState,
-      params: {
-        method: "patch",
-        url: "/websites/:website_id",
-        data: { title: editorTitle, userCode: "", websiteId: editorId },
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem(ID_TOKEN)}`,
-        },
-      },
-      requestType: "Save",
-    });
   };
 
   const publishModalToggle = useCallback(() => {
@@ -80,6 +68,28 @@ const useModal = (editorTitle, editorId) => {
     []
   );
 
+  useEffect(() => {
+    setMessage({
+      titleMessage: SAVE_MODAL_MESSAGE.titleMessage,
+      proceedButtonText: SAVE_MODAL_MESSAGE.acceptButtonMessage,
+      denyButtonText: SAVE_MODAL_MESSAGE.denyButtonMessage,
+      iconType: MODAL_ICON_STATE.saveState,
+      params: {
+        method: "patch",
+        url: "/websites/:website_id",
+        data: {
+          title: editorTitle,
+          editorCode: userCode,
+          websiteId: currentEditorId,
+        },
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem(ID_TOKEN)}`,
+        },
+      },
+      requestType: "Save",
+    });
+  }, [userCode]);
+
   return {
     shouldDisplayModal,
     createNewSiteModalToggle,
@@ -87,6 +97,8 @@ const useModal = (editorTitle, editorId) => {
     publishModalToggle,
     closeModal,
     message,
+    userCode,
+    setUserCode,
   };
 };
 

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  DELETE_MODAL_MESSAGE,
   ID_TOKEN,
   MODAL_ICON_STATE,
   NEW_EDITOR_MODAL_MESSAGE,
@@ -63,6 +64,25 @@ const useModal = (editorTitle, editorId) => {
     });
   }, []);
 
+  const deleteSiteModalMessage = useCallback((event) => {
+    setShouldDisplayModal((state) => !state);
+    setMessage({
+      titleMessage: DELETE_MODAL_MESSAGE.titleMessage,
+      proceedButtonText: DELETE_MODAL_MESSAGE.acceptButtonMessage,
+      denyButtonText: DELETE_MODAL_MESSAGE.denyButtonMessage,
+      iconType: MODAL_ICON_STATE.deleteState,
+      modalType: "delete",
+      params: {
+        method: "delete",
+        url: "/websites/:website_id",
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem(ID_TOKEN)}`,
+          params: event.target.getAttribute("value"),
+        },
+      },
+    });
+  }, []);
+
   const closeModal = useCallback(
     () => setShouldDisplayModal((state) => !state),
     []
@@ -95,6 +115,7 @@ const useModal = (editorTitle, editorId) => {
     createNewSiteModalToggle,
     saveModalToggle,
     publishModalToggle,
+    deleteSiteModalMessage,
     closeModal,
     message,
     userCode,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -62,3 +62,12 @@ export function getElementValue(
 
   return currentElementValue;
 }
+
+export const retrieveURL = () => {
+  const currentEditorId = window.location.pathname
+    .split("/")
+    .filter((item) => item !== "editor")
+    .join("");
+
+  return currentEditorId;
+};


### PR DESCRIPTION
## 요약
- 사용자 Editor 삭제기능 추가

## 작업사항
- 사용자 메인 페이지에서 만들어놓은 Editor collections 중 하나를 선택해서 삭제시킬 수 있는 기능을 구현했습니다. 서버한테 delete 요청을 보낸 후 새롭게 바뀐 정보를 response로 받고, 바뀐 정보를 context api를 이용해서 전역 상태를 업데이트시켰습니다.
- 전역 상태 값이 업데이트된 결과를 메인 페이지에서 렌더링 되게끔 구현했습니다.

![삭제 preview](https://user-images.githubusercontent.com/83770081/173202538-c3a38eca-dff7-40c8-904c-c30fdad7f64e.gif)


## 변경로직
- 변경 로직은 없습니다.

### 변경전
- 변경전 로직은 없습니다.

### 변경후
- 변경전 로직은 없습니다.

## 기타
- 코드 리뷰해 주셔서 미리 감사합니다! 🙇🏻‍♂️
