### PR TITLE
[2022/06/13] 버튼 Radius + opacity SubToolbar 로직 연결

### DIFF
--- a/src/components/OpacityChangeSubtoolBar.js
+++ b/src/components/OpacityChangeSubtoolBar.js
@@ -8,7 +8,12 @@ function OpacityEditorSubtoolBar({ onChangeOpacity }) {
   return (
     <div className="choiceContainer">
       <SubtoolbarTitle title="Edit Opacity" />
-      <SelectDetail title="opacity" detailValue={OPACITY_RANGE} onChange={onChangeOpacity}/>
+      <SelectDetail
+        title="opacity"
+        className="opacity"
+        detailValue={OPACITY_RANGE}
+        onChange={onChangeOpacity}
+      />
     </div>
   );
 }

--- a/src/components/SelectDetailSubtoolBar.js
+++ b/src/components/SelectDetailSubtoolBar.js
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
 
-function SelectDetailSubtoolBar({ detailValue, className, handleImgOpacity }) {
+import { InputFieldContext } from "../context/subToolbarContext";
+
+function SelectDetailSubtoolBar({ detailValue, className }) {
+  const { handleInputChange } = useContext(InputFieldContext);
+
   return (
     <SelectBody className={className}>
-      <select className={className} onChange={handleImgOpacity}>
+      <select className={className} onChange={handleInputChange}>
         {detailValue &&
           detailValue.map((value) => (
             <option key={value} value={value}>
@@ -32,7 +36,7 @@ const SelectBody = styled.div`
     font-weight: 400;
     padding: ${(props) => (props.className === "font" ? "1px" : "8px")};
     border: ${(props) =>
-    props.className === "font" ? null : "1px solid #e5e5e5"};
+      props.className === "font" ? null : "1px solid #e5e5e5"};
     margin-left: ${(props) => (props.className === "font" ? null : "12px")};
     cursor: pointer;
   }

--- a/src/context/subToolbarContext.js
+++ b/src/context/subToolbarContext.js
@@ -6,7 +6,7 @@ const SubToolbarContext = createContext(undefined);
 const InputFieldContext = createContext(undefined);
 
 const SubToolbarTypeProvider = ({ children }) => {
-  const [subToolbarType, setSubToolbarType] = useState();
+  const [subToolbarType, setSubToolbarType] = useState(null);
   const {
     inputValue,
     shouldEditValue,
@@ -15,10 +15,19 @@ const SubToolbarTypeProvider = ({ children }) => {
     shouldAddLink,
     toggleAddLink,
     setShouldAddLink,
+    buttonRadius,
+    setButtonRadius,
+    buttonOpacity,
+    setButtonOpacity,
   } = useInput();
 
   return (
-    <SubToolbarContext.Provider value={{ subToolbarType, setSubToolbarType }}>
+    <SubToolbarContext.Provider
+      value={{
+        subToolbarType,
+        setSubToolbarType,
+      }}
+    >
       <InputFieldContext.Provider
         value={{
           inputValue,
@@ -28,6 +37,10 @@ const SubToolbarTypeProvider = ({ children }) => {
           shouldAddLink,
           toggleAddLink,
           setShouldAddLink,
+          buttonRadius,
+          setButtonRadius,
+          buttonOpacity,
+          setButtonOpacity,
         }}
       >
         {children}

--- a/src/hooks/useInput.js
+++ b/src/hooks/useInput.js
@@ -4,11 +4,17 @@ const useInput = (currentLocationBeingUsed, value) => {
   const [inputValue, setInputValue] = useState("https://");
   const [shouldEditValue, setShouldEditValue] = useState(false);
   const [shouldAddLink, setShouldAddLink] = useState(false);
+  const [buttonRadius, setButtonRadius] = useState(null);
+  const [buttonOpacity, setButtonOpacity] = useState(null);
   const [userTitle, setUserTitle] = useState();
 
   const handleInputChange = (event) => {
     if (currentLocationBeingUsed === "editor") {
       setUserTitle(event.target.value);
+    } else if (event.target.className === "buttonRadius") {
+      setButtonRadius(event.target.value);
+    } else if (event.target.className === "opacity") {
+      setButtonOpacity(event.target.value);
     } else {
       setInputValue(event.target.value);
     }
@@ -44,6 +50,9 @@ const useInput = (currentLocationBeingUsed, value) => {
     setShouldAddLink,
     userTitle,
     setUserTitle,
+    buttonRadius,
+    buttonOpacity,
+    setButtonOpacity,
   };
 };
 

--- a/src/hooks/useResize.js
+++ b/src/hooks/useResize.js
@@ -13,8 +13,13 @@ function useResize() {
   const [shouldEditText, setShouldEditText] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const { setSubToolbarType } = useContext(SubToolbarContext);
-  const { inputValue, shouldAddLink, setShouldAddLink } =
-    useContext(InputFieldContext);
+  const {
+    inputValue,
+    shouldAddLink,
+    setShouldAddLink,
+    buttonRadius,
+    buttonOpacity,
+  } = useContext(InputFieldContext);
 
   let leftOrRightDirection = "";
   let oldPageX = 0;
@@ -102,6 +107,7 @@ function useResize() {
     if (targetRef.current && event.target === targetRef.current) {
       if (targetRef.current.tagName === "BUTTON") {
         targetRef.current.style.border = "1px solid #e5e5e5";
+        targetRef.current.previousSibling.remove();
       } else {
         targetRef.current.style.border = "none";
         targetRef.current.previousSibling.remove();
@@ -131,10 +137,10 @@ function useResize() {
       targetRef.current.style.border = "2px dashed black";
 
       targetRef.current.insertAdjacentElement("beforebegin", deleteButton);
-      targetRef.current.insertAdjacentElement("afterend", editTextButton);
 
       if (targetRef.current.tagName !== "BUTTON") {
         targetRef.current.style.padding = "7px 10px";
+        targetRef.current.insertAdjacentElement("afterend", editTextButton);
       }
 
       targetRef.current.onmousedown = handleMouseDown;
@@ -156,6 +162,10 @@ function useResize() {
     ) {
       if (targetRef.current.tagName === "BUTTON") {
         targetRef.current.style.border = "1px solid #e5e5e5";
+
+        if (targetRef.current.previousSibling) {
+          targetRef.current.previousSibling.remove();
+        }
       } else {
         targetRef.current.style.border = "none";
 
@@ -180,10 +190,10 @@ function useResize() {
       editTextButton.onclick = editText;
       targetRef.current.style.border = "2px dashed black";
       targetRef.current.insertAdjacentElement("beforebegin", deleteButton);
-      targetRef.current.insertAdjacentElement("afterend", editTextButton);
 
       if (targetRef.current.tagName !== "BUTTON") {
         targetRef.current.style.padding = "7px 10px";
+        targetRef.current.insertAdjacentElement("afterend", editTextButton);
       }
 
       targetRef.current.onmousedown = handleMouseDown;
@@ -209,6 +219,15 @@ function useResize() {
 
     setShouldAddLink(false);
   }, [shouldAddLink]);
+
+  useEffect(() => {
+    if (!targetRef.current) return;
+
+    if (targetRef.current.tagName === "BUTTON") {
+      targetRef.current.style.borderRadius = `${buttonRadius}px`;
+      targetRef.current.style.opacity = buttonOpacity;
+    }
+  }, [buttonRadius, buttonOpacity]);
 
   return [handleResizeTarget, isResizing, setIsResizing];
 }

--- a/src/hooks/useResize.js
+++ b/src/hooks/useResize.js
@@ -1,5 +1,4 @@
 import { useContext, useEffect, useRef, useState } from "react";
-import { MdClose } from "react-icons/md";
 
 import {
   InputFieldContext,
@@ -11,6 +10,7 @@ import { generateEditorDeleteElement } from "../utils/index";
 function useResize() {
   const parentRef = useRef(null);
   const targetRef = useRef(null);
+  const [shouldEditText, setShouldEditText] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const { setSubToolbarType } = useContext(SubToolbarContext);
   const { inputValue, shouldAddLink, setShouldAddLink } =
@@ -22,6 +22,8 @@ function useResize() {
   let startY = null;
 
   const handleMouseMove = (event) => {
+    if (shouldEditText) return;
+
     let [currentElementWidth, currentElementHeight] = getElementValue(
       targetRef.current
     );
@@ -68,6 +70,17 @@ function useResize() {
     }
   };
 
+  const editText = (event) => {
+    if (!shouldEditText) {
+      event.target.previousSibling.contentEditable = true;
+      event.target.previousSibling.focus();
+    } else {
+      event.target.previousSibling.contentEditable = false;
+    }
+
+    setShouldEditText((state) => !state);
+  };
+
   const handleResizeTarget = (event) => {
     startX = event.clientX;
     startY = event.clientY;
@@ -91,7 +104,8 @@ function useResize() {
         targetRef.current.style.border = "1px solid #e5e5e5";
       } else {
         targetRef.current.style.border = "none";
-        targetRef.current.childNodes[1].remove();
+        targetRef.current.previousSibling.remove();
+        targetRef.current.nextSibling.remove();
       }
       setSubToolbarType(targetRef.current.tagName);
 
@@ -104,11 +118,20 @@ function useResize() {
     if (!targetRef.current && event.target.tagName !== "DIV") {
       targetRef.current = event.target;
 
-      const closeButton = generateEditorDeleteElement(targetRef.current);
-
+      const deleteButton = generateEditorDeleteElement(
+        targetRef.current,
+        "&#x2715;"
+      );
+      const editTextButton = generateEditorDeleteElement(
+        targetRef.current,
+        "&#x270E;",
+        true
+      );
+      editTextButton.onclick = editText;
       targetRef.current.style.border = "2px dashed black";
 
-      targetRef.current.appendChild(closeButton);
+      targetRef.current.insertAdjacentElement("beforebegin", deleteButton);
+      targetRef.current.insertAdjacentElement("afterend", editTextButton);
 
       if (targetRef.current.tagName !== "BUTTON") {
         targetRef.current.style.padding = "7px 10px";
@@ -131,19 +154,33 @@ function useResize() {
       event.target !== targetRef.current &&
       event.target.tagName !== "DIV"
     ) {
-      const closeButton = generateEditorDeleteElement(targetRef.current);
-
       if (targetRef.current.tagName === "BUTTON") {
         targetRef.current.style.border = "1px solid #e5e5e5";
       } else {
         targetRef.current.style.border = "none";
-        targetRef.current.childNodes[1].remove();
+
+        if (targetRef.current.previousSibling) {
+          targetRef.current.previousSibling.remove();
+          targetRef.current.nextSibling.remove();
+        }
       }
 
       targetRef.current = event.target;
 
+      const deleteButton = generateEditorDeleteElement(
+        targetRef.current,
+        "&#x2715;"
+      );
+      const editTextButton = generateEditorDeleteElement(
+        targetRef.current,
+        "&#x270E;",
+        true
+      );
+
+      editTextButton.onclick = editText;
       targetRef.current.style.border = "2px dashed black";
-      targetRef.current.appendChild(closeButton);
+      targetRef.current.insertAdjacentElement("beforebegin", deleteButton);
+      targetRef.current.insertAdjacentElement("afterend", editTextButton);
 
       if (targetRef.current.tagName !== "BUTTON") {
         targetRef.current.style.padding = "7px 10px";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -91,8 +91,14 @@ export const generateEditorDeleteElement = (
 
   const deleteCurrentElement = (event) => {
     event.stopPropagation();
-    event.target.nextSibling.remove();
-    event.target.nextElementSibling.remove();
+
+    if (event.target.nextSibling.tagName === "BUTTON") {
+      event.target.nextSibling.remove();
+    } else {
+      event.target.nextElementSibling.remove();
+      event.target.nextSibling.remove();
+    }
+
     event.target.remove();
   };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -76,26 +76,62 @@ export const sendUserToHomepage = () => {
   window.location.replace("/");
 };
 
-export const generateEditorDeleteElement = () => {
-  const deleteNodeElement = document.createElement("p");
+export const deleteCurrentElement = (event) => {
+  event.stopPropagation();
+  event.target.nextSibling.remove();
+  event.target.nextElementSibling.remove();
+};
+
+export const generateEditorDeleteElement = (
+  clickedNode,
+  icon,
+  editIcon = false
+) => {
+  const extraIconElement = document.createElement("p");
 
   const deleteCurrentElement = (event) => {
     event.stopPropagation();
-    event.target.parentNode.remove();
+    event.target.nextSibling.remove();
+    event.target.nextElementSibling.remove();
+    event.target.remove();
   };
 
-  deleteNodeElement.style.display = "flex";
-  deleteNodeElement.style.justifyContent = "center";
-  deleteNodeElement.style.alignItems = "center";
-  deleteNodeElement.style.position = "absolute";
-  deleteNodeElement.innerHTML = "&#x2715;";
-  deleteNodeElement.style.background = "rgba(0,0,0,0.4)";
-  deleteNodeElement.style.color = "white";
-  deleteNodeElement.style.borderRadius = "50%";
-  deleteNodeElement.style.width = "30px";
-  deleteNodeElement.style.height = "30px";
-  deleteNodeElement.style.fontSize = "23px";
-  deleteNodeElement.onclick = deleteCurrentElement;
+  const extraIconMouseOverEffect = (event) => {
+    event.target.style.transform = "scale(1.1)";
+  };
 
-  return deleteNodeElement;
+  const extraIconMouseLeaveEffect = (event) => {
+    event.target.style.transform = "scale(1)";
+  };
+
+  extraIconElement.style.display = "flex";
+  extraIconElement.style.justifyContent = "center";
+  extraIconElement.style.alignItems = "center";
+  extraIconElement.style.position = "absolute";
+  extraIconElement.innerHTML = icon;
+  extraIconElement.style.background = "rgba(0,0,0,0.7)";
+  extraIconElement.style.color = "white";
+  extraIconElement.style.borderRadius = "50%";
+  extraIconElement.style.width = "30px";
+  extraIconElement.style.height = "30px";
+  extraIconElement.style.cursor = "pointer";
+  extraIconElement.style.transition = "all 0.15s ease";
+  extraIconElement.style.zIndex = "100";
+
+  if (editIcon) {
+    extraIconElement.style.left = `${clickedNode.offsetLeft + 25}px`;
+    extraIconElement.style.top = `${clickedNode.offsetTop - 20}px`;
+    extraIconElement.onmouseleave = extraIconMouseLeaveEffect;
+    extraIconElement.onmouseover = extraIconMouseOverEffect;
+  } else {
+    extraIconElement.style.left = `${clickedNode.offsetLeft - 15}px`;
+    extraIconElement.style.top = `${clickedNode.offsetTop - 20}px`;
+    extraIconElement.onmouseleave = extraIconMouseLeaveEffect;
+    extraIconElement.onmouseover = extraIconMouseOverEffect;
+    extraIconElement.onclick = deleteCurrentElement;
+  }
+
+  extraIconElement.style.fontSize = "23px";
+
+  return extraIconElement;
 };


### PR DESCRIPTION
## 요약
- 버튼 Opacity 변경 기능 구현
- 버튼 Border Radius 변경 기능 구현

## 작업사항
- 버튼 SubToolbar을 이용해서 버튼의 border radius + opacity을 조절할 수 있습니다. useInput 커스텀 훅을 SubToolbar select 옵션이랑 연결해서, 상태 값 변경이 useEffect의 dependency에서 인식되면 변경되게끔 구현해봤습니다!

![Button css Preview](https://user-images.githubusercontent.com/83770081/173252079-d4ab5bb2-cf8c-4e4d-b378-c37dec8f218b.gif)


## 변경로직

- SubToolbar select onChange부분을 useInput 커스텀 훅을 연결해줬습니다. 이러면 SubToolbar select가 변경되면 한곳에서 관리를 할 수 있어서 편리할 거 같다는 생각이 들어서 적용해봤습니다.


 ### 변경전

**SelectDetailSubToolbar.js**

```
function SelectDetailSubtoolBar({ detailValue, className, handleImgOpacity }) {
  return (
    <SelectBody className={className}>
      <select className={className} onChange={handleImgOpacity}>
        {detailValue &&
          detailValue.map((value) => (
            <option key={value} value={value}>
              {value}
            </option>
          ))}
      </select>
    </SelectBody>
  );
}

```


### 변경후

**SelectDetailSubToolbar.js**

```
function SelectDetailSubtoolBar({ detailValue, className }) {
  const { handleInputChange } = useContext(InputFieldContext);

  return (
    <SelectBody className={className}>
      <select className={className} onChange={handleInputChange}>
        {detailValue &&
          detailValue.map((value) => (
            <option key={value} value={value}>
              {value}
            </option>
          ))}
      </select>
    </SelectBody>
  );
}
```

## 기타
- 급하게 구현하다 보니깐 코드가 엉망이네요... 같이 열심히 리팩토링해봐요 😅
- 코드 리뷰해 주셔서 미리 감사합니다! 🙇🏻‍♂️
