### PR TITLE
[2022/06/15] 사용자 Editor 버전 컨트롤 구현

### DIFF
--- a/src/components/DeployedWebsite.js
+++ b/src/components/DeployedWebsite.js
@@ -1,11 +1,10 @@
 import { useContext, useEffect, useRef } from "react";
-import styled from "styled-components";
 
 import { UserContext } from "../context/userContext";
 import useAxios from "../hooks/useAxios";
 
 function DeployedWebsite({ children }) {
-  const { editor } = useContext(UserContext);
+  const { editor, setEditor } = useContext(UserContext);
   const mainpageRef = useRef(null);
   const deployedEditorURL = window.location.pathname.split("/")[2];
   const { fetchData } = useAxios({
@@ -22,9 +21,11 @@ function DeployedWebsite({ children }) {
 
   useEffect(() => {
     if (editor) {
-      mainpageRef.current.innerHTML = editor.result.userSavedCode;
-      console.log(editor);
+      const savedCodeCollection = editor.result.userSavedCode;
+      mainpageRef.current.innerHTML = savedCodeCollection[0].code;
     }
+
+    setEditor(null);
   }, [editor]);
 
   return <div ref={mainpageRef}>{children}</div>;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -21,10 +21,14 @@ import Modal from "./Modal";
 import ModalContent from "./ModalContent";
 import Navigation from "./Navigation";
 import RightToolbar from "./RightToolbar";
+import VersionLog from "./VersionLog";
 
 function Editor() {
   const currentEditorId = retrieveURL();
   const [parentRefState, setParentRefState] = useState("");
+  const [shouldShowDifferentVersion, setShouldShowDifferentVersion] =
+    useState(false);
+  const [displayingVersion, setDisplayingVersion] = useState(null);
   const { editor, title } = useContext(UserContext);
   const { handleLogout } = useLogout();
   const { userTitle, shouldEditValue, handleInputChange, toggleInputChange } =
@@ -44,6 +48,10 @@ function Editor() {
   const [imageOpacity, setImageOpacity] = useState(1);
   const [imageBrightness, setImageBrightness] = useState(1);
   const [imageBlur, setImageBlur] = useState(0);
+
+  const toggleSavedVersionHistory = () => {
+    setShouldShowDifferentVersion((state) => !state);
+  };
 
   const handleImgOpacity = (event) => {
     setImageOpacity(event.target.value);
@@ -91,6 +99,12 @@ function Editor() {
     }
   };
 
+  const handleDisplayingVersionChange = (event) => {
+    setDisplayingVersion(
+      event.target.parentNode.parentNode.getAttribute("value")
+    );
+  };
+
   return (
     <>
       {shouldDisplayModal && (
@@ -135,6 +149,11 @@ function Editor() {
           <Button handleClick={saveModalToggle} mainButton={false}>
             Save
           </Button>
+          <Button handleClick={toggleSavedVersionHistory} mainButton={false}>
+            {shouldShowDifferentVersion
+              ? "Close Saved Version Log"
+              : "Saved Version Log"}
+          </Button>
           <Button handleClick={toggleWideView} mainButton={false}>
             Wide View
           </Button>
@@ -154,12 +173,19 @@ function Editor() {
           displayWideView={shouldShowWideView}
           retrieveParentRefState={setParentRefState}
           backgroundColorName={backgroundColor}
+          editorVersion={displayingVersion}
         />
-        {!shouldShowWideView && (
+        {!shouldShowWideView && !shouldShowDifferentVersion && (
           <RightToolbar
             onChangeOpacity={handleImgOpacity}
             onChangeBrightness={handleImgBrightness}
             onChangeBlur={handleImgBlur}
+          />
+        )}
+        {shouldShowDifferentVersion && (
+          <VersionLog
+            handleVersionChange={handleDisplayingVersionChange}
+            information={editor}
           />
         )}
       </EditorBody>

--- a/src/components/EditorTemplate.js
+++ b/src/components/EditorTemplate.js
@@ -19,6 +19,7 @@ function EditorTemplate({
   saveUserCode,
   editorInformation,
   retrieveParentRefState,
+  editorVersion,
 }) {
   const [handleResizeTarget, isResizing, setIsResizing] = useResize();
   const [parentRef, targetRef] = useDragAndDrop(isResizing, setIsResizing);
@@ -134,9 +135,13 @@ function EditorTemplate({
 
   useEffect(() => {
     if (!editorInformation.result) return;
-
-    parentRef.current.innerHTML = editorInformation.result.userSavedCode;
-  }, [editorInformation.result[0]]);
+    const savedCodeCollection = editorInformation.result.userSavedCode;
+    if (editorVersion) {
+      parentRef.current.innerHTML = savedCodeCollection[editorVersion].code;
+    } else {
+      parentRef.current.innerHTML = savedCodeCollection[0].code;
+    }
+  }, [editorInformation.result[0], editorVersion]);
 
   useEffect(() => {
     if (parentRef.current) {

--- a/src/components/EditorToolbar.js
+++ b/src/components/EditorToolbar.js
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
 
@@ -6,13 +5,10 @@ function EditorToolbar({ children }) {
   return <Toolbar>{children}</Toolbar>;
 }
 
-EditorToolbar.propTypes = {
-  children: PropTypes.object.isRequired,
-};
-
 const Toolbar = styled.div`
   height: 84vh;
-  width: 16%;
+  width: 21%;
+  overflow-y: scroll;
   background-color: rgb(249, 250, 251);
 `;
 

--- a/src/components/ModalContent.js
+++ b/src/components/ModalContent.js
@@ -95,9 +95,9 @@ function ModalContent({
 }
 
 ModalContent.propTypes = {
-  modalText: PropTypes.string.isRequired,
-  primaryButtonText: PropTypes.string.isRequired,
-  secondaryButtonText: PropTypes.string.isRequired,
+  modalText: PropTypes.string,
+  primaryButtonText: PropTypes.string,
+  secondaryButtonText: PropTypes.string,
   modalIconState: PropTypes.string,
   handleClick: PropTypes.func.isRequired,
 };
@@ -140,4 +140,5 @@ const ImgURLMocalInputContainer = styled.p`
     margin-bottom: 40px;
   }
 `;
+
 export default ModalContent;

--- a/src/components/RightToolbar.js
+++ b/src/components/RightToolbar.js
@@ -42,10 +42,8 @@ function RightToolbar({ onChangeOpacity, onChangeBrightness, onChangeBlur }) {
         )}
         {subToolbarType === "BUTTON" ||
         TEXT_CHOICES.includes(subToolbarType) ? (
-          <>
             <ColorChangeSubToolBar />
-          </>
-        ) : null}
+          ) : null}
         <CanvasClearButton />
       </ToolbarContainer>
     </EditorToolbar>

--- a/src/components/VersionLog.js
+++ b/src/components/VersionLog.js
@@ -1,0 +1,91 @@
+import { useEffect, useLayoutEffect } from "react";
+import { FcImport } from "react-icons/fc";
+import styled from "styled-components";
+
+import EditorToolbar from "./EditorToolbar";
+
+function VersionLog({ handleVersionChange, information }) {
+  return (
+    <EditorToolbar>
+      <TitleContainer>
+        <p className="title">Version Log</p>
+      </TitleContainer>
+      <VersionViewContainer>
+        {information.result.userSavedCode.map((code, idx) => {
+          const savedDate = new Date(code.time).toLocaleString();
+
+          return (
+            <div key={idx}>
+              <p className="number">{idx + 1}</p>
+              <p className="savedLog">Last saved at</p>
+              <p>{savedDate}</p>
+              <p
+                className="importIcon"
+                value={idx}
+                onClick={handleVersionChange}
+              >
+                <FcImport value={idx} />
+              </p>
+            </div>
+          );
+        })}
+      </VersionViewContainer>
+    </EditorToolbar>
+  );
+}
+
+const TitleContainer = styled.div`
+  margin-top: 25px;
+  text-align: center;
+
+  .title {
+    font-size: 23px;
+  }
+`;
+
+const VersionViewContainer = styled.div`
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 20px;
+    padding: 2px 5px;
+    border: 2px dashed #e5e5e5;
+    border-radius: 7px;
+    user-select: none;
+  }
+
+  p {
+    font-size: 15px;
+    font-weight: 300;
+    text-align: center;
+  }
+
+  .savedLog {
+    margin-bottom: 5px;
+    font-size: 17px;
+    text-align: center;
+    font-weight: 400;
+  }
+
+  .importIcon {
+    padding-top: 10px;
+    font-size: 50px;
+    transition: all 0.2s ease;
+    width: 50px;
+    cursor: pointer;
+
+    :hover {
+      opacity: 0.7;
+      transform: scale(1.2);
+    }
+  }
+
+  .number {
+    margin-top: 2px;
+    margin-bottom: 4px;
+    font-size: 25px;
+  }
+`;
+
+export default VersionLog;

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -125,7 +125,7 @@ const useModal = (editorTitle, editorId) => {
       denyButtonText: SAVE_MODAL_MESSAGE.denyButtonMessage,
       iconType: MODAL_ICON_STATE.saveState,
       params: {
-        method: "patch",
+        method: "post",
         url: "/websites/:website_id",
         data: {
           title: editorTitle,


### PR DESCRIPTION
## 요약
- 과거에 저장된 코드로 언제든지 되돌아갈 수 있는 기능 구현

## 작업사항
버전 컨트롤할 수 있는 기능을 구현해봤습니다. 사용자가 예전에 저장한 코드로 돌아가고 싶을 때 시간, 날짜를 보고 예전 코드로 돌아갈 수 있게 구현해봤습니다.

만약 사용자가 구버전에서 새롭게 작성 후 코드 저장을 하면 구버전 + 새로운 버전이 합쳐져서 저장이 됩니다.

![버전 컨트롤 preview](https://user-images.githubusercontent.com/83770081/173753323-65a539c2-8633-4ddd-9586-f0526a753f9a.gif)


## 변경로직
- PATCH요청에서 POST로 변경

### 변경전
- 변경된 부분이 크지 않아서 코드는 첨부하지 않겠습니다.

### 변경 후
- 변경 후 부분이 크지 않아서 코드는 첨부하지 않겠습니다.

## 기타
- 추가로 ctrl + z할경우 그 전 단계로 가는 것을 한번 구현해보겠습니다.
- 코드 리뷰해 주셔서 미리 감사합니다.  🙇🏻‍♂️