### PR TITLE
[2022/06/17] 이미지 resize 로직 버그 해결 + 각종 버그 해결

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -45,26 +45,12 @@ function Editor() {
   } = useModal(userTitle, currentEditorId);
 
   const [backgroundColor, setBackgroundColor] = useState("");
-  const [imageOpacity, setImageOpacity] = useState(1);
-  const [imageBrightness, setImageBrightness] = useState(1);
-  const [imageBlur, setImageBlur] = useState(0);
   const [clearCanvas, setClearCanvas] = useState(false);
 
   const toggleSavedVersionHistory = () => {
     setShouldShowDifferentVersion((state) => !state);
   };
 
-  const handleImgOpacity = (event) => {
-    setImageOpacity(event.target.value);
-  };
-
-  const handleImgBrightness = (event) => {
-    setImageBrightness(event.target.value);
-  };
-
-  const handleImgBlur = (event) => {
-    setImageBlur(event.target.value);
-  };
   const toggleWideView = () => {
     setShouldShowWideView((state) => !state);
   };
@@ -186,13 +172,7 @@ function Editor() {
           clearCanvas={clearCanvas}
           handleCanvas={setClearCanvas}
         />
-        {!shouldShowWideView && !shouldShowDifferentVersion && (
-          <RightToolbar
-            onChangeOpacity={handleImgOpacity}
-            onChangeBrightness={handleImgBrightness}
-            onChangeBlur={handleImgBlur}
-          />
-        )}
+        {!shouldShowWideView && !shouldShowDifferentVersion && <RightToolbar />}
         {shouldShowDifferentVersion && (
           <VersionLog
             handleVersionChange={handleDisplayingVersionChange}

--- a/src/components/EditorTemplate.js
+++ b/src/components/EditorTemplate.js
@@ -243,7 +243,7 @@ const EditorTemplateBody = styled.div`
   position: relative;
   height: 78vh;
   width: 100%;
-  margin: 20px;
+  margin: ${(props) => (props.wideView ? "0px" : "20px")};
   overflow-y: scroll;
   box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.05);
   background-color: white;

--- a/src/components/ImageBlurSubtoolBar.js
+++ b/src/components/ImageBlurSubtoolBar.js
@@ -5,7 +5,7 @@ import { SubToolbarContext } from "../context/subToolbarContext";
 import SubtoolbarTitle from "./SubtoolbarTitle";
 
 function ImageBlurSubtoolBar() {
-  const { setImageBlur } = useContext(SubToolbarContext);
+  const { imageBlur, setImageBlur } = useContext(SubToolbarContext);
 
   const handleImageBlur = (event) => {
     setImageBlur(event.target.value);
@@ -22,6 +22,7 @@ function ImageBlurSubtoolBar() {
           max="10"
           step="0.05"
           list="tickmarks"
+          value={imageBlur}
           onChange={handleImageBlur}
         />
       </BlurBar>

--- a/src/hooks/useResize.js
+++ b/src/hooks/useResize.js
@@ -86,7 +86,6 @@ function useResize() {
     }
   };
 
-  // targetRef.current.tagName === "IMG";
   const handleMouseDown = () => {
     if (targetRef.current) {
       targetRef.current.onmousemove = handleMouseMove;

--- a/src/hooks/useResize.js
+++ b/src/hooks/useResize.js
@@ -61,10 +61,7 @@ function useResize() {
       } else if (leftOrRightDirection === "left") {
         targetRef.current.style.fontSize = `${(currentElementFontSize -= 1)}px`;
       }
-    } else if (
-      targetRef.current.tagName === "BUTTON" ||
-      targetRef.current.tagName === "IMG"
-    ) {
+    } else if (targetRef.current.tagName === "BUTTON") {
       let amountOfWidthToIncrease = event.clientX - startX;
       let amountOfHeightToIncrease = event.clientY - startY;
 
@@ -72,9 +69,24 @@ function useResize() {
         amountOfWidthToIncrease / 90)}px`;
       targetRef.current.style.height = `${(currentElementHeight +=
         amountOfHeightToIncrease / 90)}px`;
+    } else if (targetRef.current.tagName === "IMG") {
+      let currentImageWidth = Number(
+        targetRef.current.style.width.replace("px", "")
+      );
+      let currentImageHeight = Number(
+        targetRef.current.style.height.replace("px", "")
+      );
+      let amountOfWidthToIncrease = event.clientX - startX;
+      let amountOfHeightToIncrease = event.clientY - startY;
+
+      targetRef.current.style.width = `${(currentImageWidth +=
+        amountOfWidthToIncrease / 90)}px`;
+      targetRef.current.style.height = `${(currentImageHeight +=
+        amountOfHeightToIncrease / 90)}px`;
     }
   };
 
+  // targetRef.current.tagName === "IMG";
   const handleMouseDown = () => {
     if (targetRef.current) {
       targetRef.current.onmousemove = handleMouseMove;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -130,7 +130,7 @@ export const generateEditorDeleteElement = (
   extraIconElement.style.height = "30px";
   extraIconElement.style.cursor = "pointer";
   extraIconElement.style.transition = "all 0.15s ease";
-  extraIconElement.style.zIndex = "100";
+  extraIconElement.style.zIndex = "1000";
 
   if (editIcon) {
     extraIconElement.style.left = `${clickedNode.offsetLeft + 25}px`;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -153,8 +153,8 @@ export const generatedImageElement = (localImage) => {
   newImage.setAttribute("draggable", "false");
   newImage.setAttribute("src", `${localImage}`);
   newImage.style.position = "absolute";
-  newImage.style.maxHeight = "500px";
-  newImage.style.maxWidth = "500px";
+  newImage.style.height = "500px";
+  newImage.style.width = "500px";
   newImage.style.cursor = "pointer";
 
   return newImage;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -30,6 +30,11 @@ export const handleDrop = (trackChange) => (event) => {
   clonedNode.style.top = `${(droppedLocationTop / parentNodeHeight) * 95}%`;
   clonedNode.style.zIndex = 100;
 
+  if (clonedNode.tagName === "BUTTON") {
+    clonedNode.style.width = "120px";
+    clonedNode.style.height = "31px";
+  }
+
   trackChange((state) => [...state, event.target.innerHTML]);
 
   event.target.appendChild(clonedNode);


### PR DESCRIPTION
## 요약
- 이미지 리사이즈 버그 해결
- 이미지 Blur 버그 해결
- 버튼 width,height 적용
- 삭제,수정 아이콘 z-index 버그 해결

## 작업사항
- 이미지 resizing 할 때 지나치게 빠른 resizing이 적용되는 문제를 해결했습니다. 이제는 이미지 크기 조정을 진행할 때 천천히 크기 조정 가능하고 사용자가 화면 크기보다 큰 이미지를 올릴 때 고정으로 `width 500px`, `height 500px`인 상태로 업로드가 됩니다.

![Image resize preview](https://user-images.githubusercontent.com/83770081/174284552-5c07c7ec-de36-494f-b95c-4083ce5be328.gif)

## 변경로직
- 이미지 크기 조정 로직 버튼, 텍스트랑 분리

### 변경전

```
    } else if (
      targetRef.current.tagName === "BUTTON" ||
      targetRef.current.tagName === "IMG"
    ) {
      let amountOfWidthToIncrease = event.clientX - startX;
      let amountOfHeightToIncrease = event.clientY - startY;

      targetRef.current.style.width = `${(currentElementWidth +=
        amountOfWidthToIncrease / 90)}px`;
      targetRef.current.style.height = `${(currentElementHeight +=
        amountOfHeightToIncrease / 90)}px`;
    }
```

### 변경후

```
    } else if (targetRef.current.tagName === "IMG") {
      let currentImageWidth = Number(
        targetRef.current.style.width.replace("px", "")
      );
      let currentImageHeight = Number(
        targetRef.current.style.height.replace("px", "")
      );
      let amountOfWidthToIncrease = event.clientX - startX;
      let amountOfHeightToIncrease = event.clientY - startY;

      targetRef.current.style.width = `${(currentImageWidth +=
        amountOfWidthToIncrease / 90)}px`;
      targetRef.current.style.height = `${(currentImageHeight +=
        amountOfHeightToIncrease / 90)}px`;
    }
```

## 기타
- 코드 리뷰해 주셔서 미리 감사합니다! 🙇🏻‍♂️
